### PR TITLE
Add ModelQuery to sustain.proto

### DIFF
--- a/src/main/java/org/sustain/dataModeling/ModelQueryHandler.java
+++ b/src/main/java/org/sustain/dataModeling/ModelQueryHandler.java
@@ -1,0 +1,23 @@
+package org.sustain.dataModeling;
+
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sustain.ModelRequest;
+import org.sustain.ModelResponse;
+
+public class ModelQueryHandler {
+    private static final Logger log = LogManager.getLogger(ModelQueryHandler.class);
+    private final ModelRequest request;
+    private final StreamObserver<ModelResponse> responseObserver;
+
+
+    public ModelQueryHandler(ModelRequest request, StreamObserver<ModelResponse> responseObserver) {
+        this.request = request;
+        this.responseObserver = responseObserver;
+    }
+
+    public void handleQuery() {
+
+    }
+}

--- a/src/main/java/org/sustain/server/SustainServer.java
+++ b/src/main/java/org/sustain/server/SustainServer.java
@@ -8,33 +8,27 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sustain.CensusRequest;
 import org.sustain.CensusResponse;
+import org.sustain.CompoundRequest;
+import org.sustain.CompoundResponse;
 import org.sustain.DatasetRequest;
 import org.sustain.DatasetResponse;
+import org.sustain.ModelRequest;
+import org.sustain.ModelResponse;
 import org.sustain.OsmRequest;
 import org.sustain.OsmResponse;
 import org.sustain.Predicate;
 import org.sustain.SpatialOp;
 import org.sustain.SustainGrpc;
-
-import org.sustain.TargetedCensusRequest;
-import org.sustain.TargetedCensusResponse;
-import org.sustain.querier.CompoundQueryHandler;
-
 import org.sustain.SviRequest;
 import org.sustain.SviResponse;
-
 import org.sustain.census.CensusQueryHandler;
 import org.sustain.census.controller.SpatialQueryUtil;
+import org.sustain.dataModeling.ModelQueryHandler;
 import org.sustain.openStreetMaps.OsmQueryHandler;
 import org.sustain.otherDatasets.DatasetQueryHandler;
+import org.sustain.querier.CompoundQueryHandler;
 import org.sustain.svi.SviController;
 import org.sustain.util.Constants;
-
-import org.sustain.JoinOperator;
-import org.sustain.ComparisonOperator;
-import org.sustain.CompoundResponse;
-import org.sustain.CompoundRequest;
-import org.sustain.Query;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -100,6 +94,11 @@ public class SustainServer {
         public void censusQuery(CensusRequest request, StreamObserver<CensusResponse> responseObserver) {
             CensusQueryHandler handler = new CensusQueryHandler(request, responseObserver);
             handler.handleCensusQuery();
+        }
+
+        @Override
+        public void modelQuery(ModelRequest request, StreamObserver<ModelResponse> responseObserver) {
+            ModelQueryHandler handler = new ModelQueryHandler(request, responseObserver);
         }
 
         @Override

--- a/src/main/proto/sustain.proto
+++ b/src/main/proto/sustain.proto
@@ -27,6 +27,16 @@ service Sustain{
   rpc ExecuteTargetedCensusQuery (TargetedCensusRequest) returns (stream TargetedCensusResponse) {}
 
   rpc CompoundQuery (CompoundRequest) returns (stream CompoundResponse) {}
+
+  rpc ModelQuery (ModelRequest) returns (ModelResponse) {}
+}
+
+message ModelRequest {
+  string request = 1;
+}
+
+message ModelResponse {
+  string results = 1;
 }
 
 message SviRequest {


### PR DESCRIPTION
Request and Response for ModelQuery will be as follows.

```proto
message ModelRequest {
  string request = 1;
}

message ModelResponse {
  string results = 1;
}
```
The reason for keeping the request and response simple is because it will allow us to change the representation of the request and response without having to  change the service -- thereby avoiding the need to compile and add the proto file to the aperture client every time a change is made i.e. the query service will need not be changed.

We will make the request a JSON object similar to the following:
```json

[
  {
    "operation": "clustering",
    "algorithm": "k-means",
    "collections": [
      {
        "name": "hospitals_geo",
        "features": ["properties.POPULATION", "properties.BEDS"]
      },
      {
        "name": "public_schools",
        "features": ["properties.ENROLLMENT", "properties.FT_TEACHER"]
      }
    ]
  }
]
```

And the response associated with the preceding request will resemble the following

```json

{
  "operation": "clustering",
  "results": {
    "no-of-clusters": 2,
    "cluster-centers": [
      [0.1, 0.124],
      [0.235, 0.998]
    ]
  }
}
```