### PR TITLE
Use persist/unpersist for linear regression models

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.json:json:20171018'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8'
-    implementation group: 'org.mongodb', name: 'mongo-java-driver', version: '3.12.5'
+    implementation group: 'org.mongodb', name: 'mongo-java-driver', version: '4.2.2'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.7'
     implementation 'org.scala-lang:scala-library:2.12.10'
     implementation "org.apache.spark:spark-core_2.12:3.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.json:json:20171018'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8'
-    implementation group: 'org.mongodb', name: 'mongo-java-driver', version: '3.12.8'
+    implementation group: 'org.mongodb', name: 'mongo-java-driver', version: '3.12.15'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.7'
     implementation 'org.scala-lang:scala-library:2.12.10'
     implementation "org.apache.spark:spark-core_2.12:3.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.json:json:20171018'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8'
-    implementation group: 'org.mongodb', name: 'mongo-java-driver', version: '4.2.2'
+    implementation group: 'org.mongodb', name: 'mongo-java-driver', version: '3.12.8'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.7'
     implementation 'org.scala-lang:scala-library:2.12.10'
     implementation "org.apache.spark:spark-core_2.12:3.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.json:json:20171018'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8'
-    implementation group: 'org.mongodb', name: 'mongo-java-driver', version: '3.12.15'
+    implementation group: 'org.mongodb', name: 'mongo-java-driver', version: '3.12.8'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.7'
     implementation 'org.scala-lang:scala-library:2.12.10'
     implementation "org.apache.spark:spark-core_2.12:3.0.1"

--- a/src/main/java/org/sustain/SparkManager.java
+++ b/src/main/java/org/sustain/SparkManager.java
@@ -18,7 +18,6 @@ public class SparkManager {
 
     private static final Logger log = LogManager.getFormatterLogger(SparkManager.class);
 
-
     protected ExecutorService executorService; 
     protected List<String> jars;
     private String sparkMaster;
@@ -67,9 +66,7 @@ public class SparkManager {
             .getOrCreate();
 
         // if they don't exist - add JARs to SparkContext
-        JavaSparkContext sparkContext =
-            new JavaSparkContext(sparkSession.sparkContext());
-        sparkContext.setCheckpointDir("/s/parsons/b/others/sustain/spark/checkpoint");
+        JavaSparkContext sparkContext = new JavaSparkContext(sparkSession.sparkContext());
         for (String jar : this.jars) {
             if (!sparkContext.jars().contains(jar)) {
                 sparkContext.addJar(jar);

--- a/src/main/java/org/sustain/SparkManager.java
+++ b/src/main/java/org/sustain/SparkManager.java
@@ -2,18 +2,14 @@ package org.sustain;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 
-import org.sustain.handlers.ClusteringQueryHandler;
 import org.sustain.util.Constants;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -76,7 +72,6 @@ public class SparkManager {
         for (String jar : this.jars) {
             if (!sparkContext.jars().contains(jar)) {
                 sparkContext.addJar(jar);
-                log.info("JAR {} successfully added to cluster", jar);
             }
         }
 

--- a/src/main/java/org/sustain/SparkManager.java
+++ b/src/main/java/org/sustain/SparkManager.java
@@ -1,10 +1,13 @@
 package org.sustain;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 
+import org.sustain.handlers.ClusteringQueryHandler;
 import org.sustain.util.Constants;
 
 import java.util.ArrayList;
@@ -16,6 +19,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 public class SparkManager {
+
+    private static final Logger log = LogManager.getFormatterLogger(SparkManager.class);
+
+
     protected ExecutorService executorService; 
     protected List<String> jars;
     private String sparkMaster;
@@ -69,6 +76,7 @@ public class SparkManager {
         for (String jar : this.jars) {
             if (!sparkContext.jars().contains(jar)) {
                 sparkContext.addJar(jar);
+                log.info("JAR {} successfully added to cluster", jar);
             }
         }
 

--- a/src/main/java/org/sustain/SparkManager.java
+++ b/src/main/java/org/sustain/SparkManager.java
@@ -69,6 +69,7 @@ public class SparkManager {
         // if they don't exist - add JARs to SparkContext
         JavaSparkContext sparkContext =
             new JavaSparkContext(sparkSession.sparkContext());
+        sparkContext.setCheckpointDir("/s/parsons/b/others/sustain/spark/checkpoint");
         for (String jar : this.jars) {
             if (!sparkContext.jars().contains(jar)) {
                 sparkContext.addJar(jar);

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -172,6 +172,8 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 	private void launchModels(LinearRegressionRequest lrRequest, Dataset<Row> mongoCollection) {
 
 		// Build and run a model for each GISJoin in the request
+		int progressIndex = 0;
+		int totalModels = lrRequest.getGisJoinsCount();
 		for (String gisJoin: lrRequest.getGisJoinsList()) {
 			LinearRegressionModelImpl model = new LinearRegressionModelImpl.LinearRegressionModelBuilder()
 					.forMongoCollection(mongoCollection)
@@ -205,6 +207,8 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 					.build();
 
 			logResponse(response);
+			log.info(String.format(">>> Sending model response for GISJoin %s [%d/%d]",
+					gisJoin, progressIndex, totalModels));
 			this.responseObserver.onNext(response);
 		}
 	}

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -149,15 +149,15 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 
 		/*
 			Assemble all the feature columns into a row-oriented Vector:
-			+--------------------+--------+---------+-------+
-			|                 _id|gis_join|feature_0|  label|
-			+--------------------+--------+---------+-------+
-			|[6024fe7dc1d226e5...|G0100190|788918400|288.388|
-			|[6024fe7ec1d226e5...|G0100190|789004800|281.047|
-			|[6024fe7fc1d226e5...|G0100190|789091200|282.115|
-			|[6024fe80c1d226e5...|G0100190|789177600|286.618|
-			|[6024fe80c1d226e5...|G0100190|789264000|288.166|
-			+--------------------+--------+---------+-------+
+			+--------------------+--------+---------+-------+------------+
+			|                 _id|gis_join|feature_0|  label|    features|
+			+--------------------+--------+---------+-------+------------+
+			|[6024fe7dc1d226e5...|G0100190|788918400|288.388|[7.889184E8]|
+			|[6024fe7ec1d226e5...|G0100190|789004800|281.047|[7.890048E8]|
+			|[6024fe7fc1d226e5...|G0100190|789091200|282.115|[7.890912E8]|
+			|[6024fe80c1d226e5...|G0100190|789177600|286.618|[7.891776E8]|
+			|[6024fe80c1d226e5...|G0100190|789264000|288.166| [7.89264E8]|
+			+--------------------+--------+---------+-------+------------+
 		 */
 		VectorAssembler vectorAssembler = new VectorAssembler()
 				.setInputCols(featureColumns.toArray(new String[0]))
@@ -239,8 +239,6 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		Dataset<Row> mongoCollection = MongoSpark.load(sparkContext, mongoReadConfig).toDF();
 		processCollection(lrRequest, requestCollection, mongoCollection);
 		mongoCollection.persist();
-
-		profiler.completeTask("LOAD_MONGO_COLLECTION");
 
 		// Build and run a model for each GISJoin in the request
 		for (String gisJoin: lrRequest.getGisJoinsList()) {

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -160,7 +160,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 
 		// Persist filtered data to memory
 
-		Dataset<Row> persistedCollection = gisDataset.persist();
+		Dataset<Row> persistedCollection = gisDataset.cache();
 		//log.info(">>> mongoCollection Size: {}", readableBytes(SizeEstimator.estimate(persistedCollection)));
 		/*
 		 */

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -142,6 +142,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		log.info(">>> mongoCollection Size: {}", readableBytes(SizeEstimator.estimate(persistedCollection)));
 		profiler.completeTask("LOAD_MONGO_COLLECTION");
 
+		/*
 		// Build and run a model for each GISJoin in the request
 		for (String gisJoin: lrRequest.getGisJoinsList()) {
 
@@ -187,6 +188,8 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 			profiler.unindent();
 			this.responseObserver.onNext(response);
 		}
+		*/
+
 
 		// Unpersist collection and complete task
 		persistedCollection.unpersist(true);

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -160,7 +160,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 
 		// Persist filtered data to memory
 
-		Dataset<Row> persistedCollection = gisDataset.cache();
+		Dataset<Row> persistedCollection = gisDataset.checkpoint(true);
 		//log.info(">>> mongoCollection Size: {}", readableBytes(SizeEstimator.estimate(persistedCollection)));
 		/*
 		 */

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -131,8 +131,11 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		));
 
 		// SQL Filter by the GISJoins that they requested (i.e. WHERE gis_join IN ( value1, value2, value3 ) )
-		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").unary_$bang()
-				.isInCollection(lrRequest.getGisJoinsList()));
+		Dataset<Row> gisDataset = selected.filter("gis_join IN ( G0100290, G0100210, G0100190, G0100230 )");
+
+
+		//Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").unary_$bang()
+		//		.isInCollection(lrRequest.getGisJoinsList()));
 
 		// Persist filtered data to memory
 		Dataset<Row> persistedCollection = gisDataset.persist(MEMORY_ONLY);

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -145,11 +145,11 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		profiler.addTask("LOAD_MONGO_COLLECTION");
 		Dataset<Row> mongoCollection = MongoSpark.load(sparkContext, readConfig).toDF();
 
-		/*
+
 		// SQL Select only _id, gis_join, features, and label columns, and discard the rest
 		Dataset<Row> selected = mongoCollection.select("_id", desiredColumns(
 				requestCollection.getFeaturesList(), requestCollection.getLabel()));
-
+		/*
 		// SQL Filter by the GISJoins that they requested (i.e. WHERE gis_join IN ( value1, value2, value3 ) )
 		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join")
 				.isInCollection(lrRequest.getGisJoinsList()));
@@ -161,8 +161,10 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		// Persist filtered data to memory
 		Dataset<Row> persistedCollection = gisDataset.persist(MEMORY_ONLY);
 		log.info(">>> mongoCollection Size: {}", readableBytes(SizeEstimator.estimate(persistedCollection)));
+
+		 */
 		profiler.completeTask("LOAD_MONGO_COLLECTION");
-		*/
+
 
 		// Build and run a model for each GISJoin in the request
 		for (String gisJoin: lrRequest.getGisJoinsList()) {

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -131,7 +131,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		));
 
 		// SQL Filter by the GISJoins that they requested (i.e. WHERE gis_join IN ( value1, value2, value3 ) )
-		Dataset<Row> gisDataset = selected.filter("gis_join IN ( G0100290, G0100210, G0100190, G0100230 )");
+		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").isin("G0100290", "G0100210", "G0100190", "G0100230" ));
 
 
 		//Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").unary_$bang()

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -78,6 +78,25 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		}
 	}
 
+	private void addJars(JavaSparkContext sparkContext) {
+		String[] sparkJarPaths = {
+				"build/libs/scala-collection-compat_2.12-2.1.1.jar",
+				"build/libs/scala-library-2.12.11.jar",
+				"build/libs/scala-xml_2.12-1.2.0.jar",
+				"build/libs/scala-parser-combinators_2.12-1.1.2.jar",
+				"build/libs/mongo-spark-connector_2.12-3.0.1.jar",
+				"build/libs/spark-core_2.12-3.0.1.jar",
+				"build/libs/spark-mllib_2.12-3.0.1.jar",
+				"build/libs/spark-sql_2.12-3.0.1.jar",
+				"build/libs/bson-4.0.5.jar",
+				"build/libs/mongo-java-driver-3.12.8.jar"
+		};
+
+		for (String jar: sparkJarPaths) {
+			sparkContext.addJar(jar);
+		}
+	}
+
     @Override
     public void handleRequest() {
         if (isValid(this.request)) {
@@ -102,6 +121,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 
     @Override
     public Boolean execute(JavaSparkContext sparkContext) {
+		addJars(sparkContext);
 		Profiler profiler = new Profiler();
 		profiler.addTask("LINEAR_REGRESSION_MODELS");
 		profiler.indent();

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -164,7 +164,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join")
 				.isInCollection(lrRequest.getGisJoinsList()));
 
-		gisDataset.groupBy("gis_join").df().show();
+		gisDataset.groupBy("gis_join").agg(org.apache.spark.sql.functions.collect_list("features")).toDF("gis_join","features").show();
 		/*
 		// Create map function for Map portion of Map Reduce
 		MapFunction<Row, Tuple2<String, Double>> mapFunction = row -> new Tuple2<String, Double>(

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -154,14 +154,15 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join")
 				.isInCollection(lrRequest.getGisJoinsList()));
 
-		/*
+
 		//Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").unary_$bang()
 		//		.isInCollection(lrRequest.getGisJoinsList()));
 
 		// Persist filtered data to memory
-		Dataset<Row> persistedCollection = gisDataset.persist(MEMORY_ONLY);
-		log.info(">>> mongoCollection Size: {}", readableBytes(SizeEstimator.estimate(persistedCollection)));
 
+		Dataset<Row> persistedCollection = gisDataset.persist();
+		log.info(">>> mongoCollection Size: {}", readableBytes(SizeEstimator.estimate(persistedCollection)));
+		/*
 		 */
 		profiler.completeTask("LOAD_MONGO_COLLECTION");
 

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -142,7 +142,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		log.info(">>> mongoCollection Size: {}", readableBytes(SizeEstimator.estimate(persistedCollection)));
 		profiler.completeTask("LOAD_MONGO_COLLECTION");
 
-		/*
+
 		// Build and run a model for each GISJoin in the request
 		for (String gisJoin: lrRequest.getGisJoinsList()) {
 
@@ -188,7 +188,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 			profiler.unindent();
 			this.responseObserver.onNext(response);
 		}
-		*/
+
 
 
 		// Unpersist collection and complete task

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -127,11 +127,11 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 
 		// SQL Select only _id, gis_join, features, and label columns, and discard the rest
 		Dataset<Row> selected = mongoCollection.select("_id", desiredColumns(
-				requestCollection.getFeaturesList(), requestCollection.getLabel()
-		));
+				requestCollection.getFeaturesList(), requestCollection.getLabel()));
 
 		// SQL Filter by the GISJoins that they requested (i.e. WHERE gis_join IN ( value1, value2, value3 ) )
-		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").isInCollection(lrRequest.getGisJoinsList()));
+		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join")
+				.isInCollection(lrRequest.getGisJoinsList()));
 
 
 		//Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").unary_$bang()

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -149,12 +149,12 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		// SQL Select only _id, gis_join, features, and label columns, and discard the rest
 		Dataset<Row> selected = mongoCollection.select("_id", desiredColumns(
 				requestCollection.getFeaturesList(), requestCollection.getLabel()));
-		/*
+
 		// SQL Filter by the GISJoins that they requested (i.e. WHERE gis_join IN ( value1, value2, value3 ) )
 		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join")
 				.isInCollection(lrRequest.getGisJoinsList()));
 
-
+		/*
 		//Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").unary_$bang()
 		//		.isInCollection(lrRequest.getGisJoinsList()));
 
@@ -174,7 +174,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 			profiler.indent();
 
 			LinearRegressionModelImpl model = new LinearRegressionModelImpl.LinearRegressionModelBuilder()
-					.forMongoCollection(mongoCollection)
+					.forMongoCollection(gisDataset)
 					.forGISJoin(gisJoin)
 					.forFeatures(requestCollection.getFeaturesList())
 					.forLabel(requestCollection.getLabel())

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -161,7 +161,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		// Persist filtered data to memory
 
 		Dataset<Row> persistedCollection = gisDataset.persist();
-		log.info(">>> mongoCollection Size: {}", readableBytes(SizeEstimator.estimate(persistedCollection)));
+		//log.info(">>> mongoCollection Size: {}", readableBytes(SizeEstimator.estimate(persistedCollection)));
 		/*
 		 */
 		profiler.completeTask("LOAD_MONGO_COLLECTION");
@@ -175,7 +175,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 			profiler.indent();
 
 			LinearRegressionModelImpl model = new LinearRegressionModelImpl.LinearRegressionModelBuilder()
-					.forMongoCollection(gisDataset)
+					.forMongoCollection(persistedCollection)
 					.forGISJoin(gisJoin)
 					.forFeatures(requestCollection.getFeaturesList())
 					.forLabel(requestCollection.getLabel())

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -29,6 +29,7 @@ import org.sustain.util.Profiler;
 import org.apache.spark.util.SizeEstimator;
 import scala.Function2;
 import scala.Tuple2;
+import scala.Tuple3;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.reflect.ClassTag;
@@ -174,16 +175,21 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join")
 				.isInCollection(lrRequest.getGisJoinsList()));
 
-		gisDataset.groupBy("gis_join").df().show();
-
-		/*
 		// Create map function for Map portion of Map Reduce
-		MapFunction<Row, Tuple2<String, Double>> mapFunction = row -> new Tuple2<String, Double>(
-				row.getAs("gis_join"), row.getAs("features")
+		MapFunction<Row, Tuple3<String, Long, Double>> mapFunction = row -> new Tuple3<String, Long, Double>(
+				row.getAs("gis_join"), row.getAs("feature_0"), row.getAs("label")
 		);
 
 		// Create Encoder to convert JVM objects to Spark SQL representations
-		Encoder<Tuple2<String, Double>> encoder = Encoders.tuple(Encoders.STRING(), Encoders.DOUBLE());
+		Encoder<Tuple3<String, Long, Double>> encoder = Encoders.tuple(Encoders.STRING(), Encoders.LONG(), Encoders.DOUBLE());
+
+		gisDataset.groupBy("gis_join").df().map(mapFunction, encoder).show();
+
+		/*
+
+
+
+
 
 		// Map the Rows to KV pairs where the key is the String GISJoin, and the value is the feature
 		Dataset<Tuple2<String, Double>> keyValuePairs = gisDataset.map(mapFunction, encoder);

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -131,7 +131,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		));
 
 		// SQL Filter by the GISJoins that they requested (i.e. WHERE gis_join IN ( value1, value2, value3 ) )
-		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").isin("G0100290", "G0100210", "G0100190", "G0100230" ));
+		Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").isInCollection(lrRequest.getGisJoinsList()));
 
 
 		//Dataset<Row> gisDataset = selected.filter(selected.col("gis_join").unary_$bang()

--- a/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
+++ b/src/main/java/org/sustain/handlers/RegressionQueryHandler.java
@@ -145,6 +145,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		profiler.addTask("LOAD_MONGO_COLLECTION");
 		Dataset<Row> mongoCollection = MongoSpark.load(sparkContext, readConfig).toDF();
 
+		/*
 		// SQL Select only _id, gis_join, features, and label columns, and discard the rest
 		Dataset<Row> selected = mongoCollection.select("_id", desiredColumns(
 				requestCollection.getFeaturesList(), requestCollection.getLabel()));
@@ -161,7 +162,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 		Dataset<Row> persistedCollection = gisDataset.persist(MEMORY_ONLY);
 		log.info(">>> mongoCollection Size: {}", readableBytes(SizeEstimator.estimate(persistedCollection)));
 		profiler.completeTask("LOAD_MONGO_COLLECTION");
-
+		*/
 
 		// Build and run a model for each GISJoin in the request
 		for (String gisJoin: lrRequest.getGisJoinsList()) {
@@ -171,7 +172,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 			profiler.indent();
 
 			LinearRegressionModelImpl model = new LinearRegressionModelImpl.LinearRegressionModelBuilder()
-					.forMongoCollection(persistedCollection)
+					.forMongoCollection(mongoCollection)
 					.forGISJoin(gisJoin)
 					.forFeatures(requestCollection.getFeaturesList())
 					.forLabel(requestCollection.getLabel())
@@ -212,7 +213,7 @@ public class RegressionQueryHandler extends GrpcSparkHandler<ModelRequest, Model
 
 
 		// Unpersist collection and complete task
-		persistedCollection.unpersist(true);
+		//persistedCollection.unpersist(true);
 		profiler.completeTask("LINEAR_REGRESSION_MODELS");
 		profiler.unindent();
 		log.info(profiler.toString());

--- a/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
+++ b/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
@@ -105,10 +105,10 @@ public class LinearRegressionModelImpl {
         log.info(">>> mergedDataset Size: {}", SizeEstimator.estimate(mergedDataset));
         log.info(">>> mergedDataset explain():");
 
-        /*
         mergedDataset.explain();
         profiler.completeTask(vectorTransformTaskName);
 
+        /*
         // Create an MLLib Linear Regression object using user-specified parameters
         String lrCreateFitTaskName = String.format("LR_CREATE_FIT_%s", this.gisJoin);
         profiler.addTask(lrCreateFitTaskName);

--- a/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
+++ b/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
@@ -87,10 +87,9 @@ public class LinearRegressionModelImpl {
         log.info(">>> Building model for GISJoin {}", this.gisJoin);
 
         // Filter collection by our GISJoin
-        String filterTaskName = String.format("FILTER_GISJOIN_%s", this.gisJoin);
-        profiler.addTask(filterTaskName);
-        Dataset<Row> gisDataset = this.mongoCollection.filter(this.mongoCollection.col("gis_join").$eq$eq$eq(this.gisJoin));
-        profiler.completeTask(filterTaskName);
+        Dataset<Row> gisDataset = this.mongoCollection.filter(
+                this.mongoCollection.col("gis_join").$eq$eq$eq(this.gisJoin)
+        );
 
         // Create a VectorAssembler to assemble all the feature columns into a single column vector named "features"
         //String vectorTransformTaskName = String.format("VECTOR_TRANSFORM_%s", this.gisJoin);
@@ -110,8 +109,6 @@ public class LinearRegressionModelImpl {
 
 
         // Create an MLLib Linear Regression object using user-specified parameters
-        String lrCreateFitTaskName = String.format("LR_CREATE_FIT_%s", this.gisJoin);
-        profiler.addTask(lrCreateFitTaskName);
         LinearRegression linearRegression = new LinearRegression()
                 .setLoss(this.loss)
                 .setSolver(this.solver)
@@ -126,7 +123,6 @@ public class LinearRegressionModelImpl {
 
         // Fit the dataset with the "features" and "label" columns
         LinearRegressionModel lrModel = linearRegression.fit(gisDataset);
-        profiler.completeTask(lrCreateFitTaskName);
 
         // Save training summary
         LinearRegressionTrainingSummary summary = lrModel.summary();

--- a/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
+++ b/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
@@ -106,6 +106,7 @@ public class LinearRegressionModelImpl {
         log.info(">>> mergedDataset explain():");
 
         mergedDataset.explain();
+        mergedDataset.show();
         profiler.completeTask(vectorTransformTaskName);
 
         /*

--- a/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
+++ b/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
@@ -102,7 +102,6 @@ public class LinearRegressionModelImpl {
 
         // Transform the gisDataset to have the new "features" column vector
         Dataset<Row> mergedDataset = vectorAssembler.transform(gisDataset);
-        mergedDataset.show(5);
         log.info(">>> mergedDataset Size: {}", SizeEstimator.estimate(mergedDataset));
         log.info(">>> mergedDataset explain():");
         mergedDataset.explain();

--- a/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
+++ b/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
@@ -104,6 +104,8 @@ public class LinearRegressionModelImpl {
         Dataset<Row> mergedDataset = vectorAssembler.transform(gisDataset);
         log.info(">>> mergedDataset Size: {}", SizeEstimator.estimate(mergedDataset));
         log.info(">>> mergedDataset explain():");
+
+        /*
         mergedDataset.explain();
         profiler.completeTask(vectorTransformTaskName);
 
@@ -146,6 +148,8 @@ public class LinearRegressionModelImpl {
         this.rmse = summary.rootMeanSquaredError();
         this.r2 = summary.r2();
 
+
+         */
         log.info(">>> Finished building model for GISJoin {}", this.gisJoin);
     }
 

--- a/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
+++ b/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
@@ -109,7 +109,7 @@ public class LinearRegressionModelImpl {
         mergedDataset.show();
         profiler.completeTask(vectorTransformTaskName);
 
-        /*
+
         // Create an MLLib Linear Regression object using user-specified parameters
         String lrCreateFitTaskName = String.format("LR_CREATE_FIT_%s", this.gisJoin);
         profiler.addTask(lrCreateFitTaskName);
@@ -149,8 +149,6 @@ public class LinearRegressionModelImpl {
         this.rmse = summary.rootMeanSquaredError();
         this.r2 = summary.r2();
 
-
-         */
         log.info(">>> Finished building model for GISJoin {}", this.gisJoin);
     }
 

--- a/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
+++ b/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
@@ -89,25 +89,24 @@ public class LinearRegressionModelImpl {
         // Filter collection by our GISJoin
         String filterTaskName = String.format("FILTER_GISJOIN_%s", this.gisJoin);
         profiler.addTask(filterTaskName);
-        Dataset<Row> gisDataset = this.mongoCollection.filter(this.mongoCollection.col("gis_join").$eq$eq$eq(this.gisJoin))
-                .withColumnRenamed(this.label, "label"); // Rename the chosen label column to "label"
+        Dataset<Row> gisDataset = this.mongoCollection.filter(this.mongoCollection.col("gis_join").$eq$eq$eq(this.gisJoin));
         profiler.completeTask(filterTaskName);
 
         // Create a VectorAssembler to assemble all the feature columns into a single column vector named "features"
-        String vectorTransformTaskName = String.format("VECTOR_TRANSFORM_%s", this.gisJoin);
-        profiler.addTask(vectorTransformTaskName);
-        VectorAssembler vectorAssembler = new VectorAssembler()
-                .setInputCols(this.features.toArray(new String[0]))
-                .setOutputCol("features");
+        //String vectorTransformTaskName = String.format("VECTOR_TRANSFORM_%s", this.gisJoin);
+        //profiler.addTask(vectorTransformTaskName);
+        //VectorAssembler vectorAssembler = new VectorAssembler()
+        //        .setInputCols(this.features.toArray(new String[0]))
+        //        .setOutputCol("features");
 
         // Transform the gisDataset to have the new "features" column vector
-        Dataset<Row> mergedDataset = vectorAssembler.transform(gisDataset);
-        log.info(">>> mergedDataset Size: {}", SizeEstimator.estimate(mergedDataset));
-        log.info(">>> mergedDataset explain():");
+        //Dataset<Row> mergedDataset = vectorAssembler.transform(gisDataset);
+        //log.info(">>> mergedDataset Size: {}", SizeEstimator.estimate(mergedDataset));
+        //log.info(">>> mergedDataset explain():");
 
-        mergedDataset.explain();
-        mergedDataset.show();
-        profiler.completeTask(vectorTransformTaskName);
+        //mergedDataset.explain();
+        //mergedDataset.show();
+        //profiler.completeTask(vectorTransformTaskName);
 
 
         // Create an MLLib Linear Regression object using user-specified parameters
@@ -126,7 +125,7 @@ public class LinearRegressionModelImpl {
                 .setStandardization(this.setStandardization);
 
         // Fit the dataset with the "features" and "label" columns
-        LinearRegressionModel lrModel = linearRegression.fit(mergedDataset);
+        LinearRegressionModel lrModel = linearRegression.fit(gisDataset);
         profiler.completeTask(lrCreateFitTaskName);
 
         // Save training summary

--- a/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
+++ b/src/main/java/org/sustain/modeling/LinearRegressionModelImpl.java
@@ -79,7 +79,7 @@ public class LinearRegressionModelImpl {
         return totalIterations;
     }
 
-    public void buildAndRunModel(Profiler profiler) {
+    public void buildAndRunModel() {
 
         log.info(">>> Building model for GISJoin {}", this.gisJoin);
 
@@ -152,7 +152,7 @@ public class LinearRegressionModelImpl {
                 .withTolerance(1E-7)
                 .build();
 
-        lrModel.buildAndRunModel(new Profiler());
+        lrModel.buildAndRunModel();
         log.info("Executed LinearRegressionModelImpl.main() successfully");
         sparkContext.close();
     }

--- a/src/main/java/org/sustain/server/SustainServer.java
+++ b/src/main/java/org/sustain/server/SustainServer.java
@@ -19,7 +19,7 @@ public class SustainServer {
         "build/libs/spark-mllib_2.12-3.0.1.jar",
         "build/libs/spark-sql_2.12-3.0.1.jar",
         "build/libs/bson-4.0.5.jar",
-        "build/libs/mongo-java-driver-3.12.5.jar"
+        "build/libs/mongo-java-driver-3.12.8.jar"
     };
 
     private Server server;

--- a/src/main/java/org/sustain/server/SustainServer.java
+++ b/src/main/java/org/sustain/server/SustainServer.java
@@ -14,10 +14,10 @@ public class SustainServer {
 
     private static final Logger log = LogManager.getLogger(SustainServer.class);
     private static final String[] sparkJarPaths = {
-            "build/scala-collection-compat_2.12-2.1.1.jar",
-            "build/scala-library-2.12.11.jar",
-            "build/scala-xml_2.12-1.2.0.jar",
-            "build/scala-parser-combinators_2.12-1.1.2.jar",
+            "build/libs/scala-collection-compat_2.12-2.1.1.jar",
+            "build/libs/scala-library-2.12.11.jar",
+            "build/libs/scala-xml_2.12-1.2.0.jar",
+            "build/libs/scala-parser-combinators_2.12-1.1.2.jar",
             "build/libs/mongo-spark-connector_2.12-3.0.1.jar",
             "build/libs/spark-core_2.12-3.0.1.jar",
             "build/libs/spark-mllib_2.12-3.0.1.jar",

--- a/src/main/java/org/sustain/server/SustainServer.java
+++ b/src/main/java/org/sustain/server/SustainServer.java
@@ -14,12 +14,16 @@ public class SustainServer {
 
     private static final Logger log = LogManager.getLogger(SustainServer.class);
     private static final String[] sparkJarPaths = {
-        "build/libs/mongo-spark-connector_2.12-3.0.1.jar",
-        "build/libs/spark-core_2.12-3.0.1.jar",
-        "build/libs/spark-mllib_2.12-3.0.1.jar",
-        "build/libs/spark-sql_2.12-3.0.1.jar",
-        "build/libs/bson-4.0.5.jar",
-        "build/libs/mongo-java-driver-3.12.8.jar"
+            "build/scala-collection-compat_2.12-2.1.1.jar",
+            "build/scala-library-2.12.11.jar",
+            "build/scala-xml_2.12-1.2.0.jar",
+            "build/scala-parser-combinators_2.12-1.1.2.jar",
+            "build/libs/mongo-spark-connector_2.12-3.0.1.jar",
+            "build/libs/spark-core_2.12-3.0.1.jar",
+            "build/libs/spark-mllib_2.12-3.0.1.jar",
+            "build/libs/spark-sql_2.12-3.0.1.jar",
+            "build/libs/bson-4.0.5.jar",
+            "build/libs/mongo-java-driver-3.12.8.jar"
     };
 
     private Server server;

--- a/src/main/java/org/sustain/server/SustainService.java
+++ b/src/main/java/org/sustain/server/SustainService.java
@@ -84,7 +84,6 @@ public class SustainService extends SustainGrpc.SustainImplBase {
         }
 
         handler.handleRequest();
-        responseObserver.onCompleted();
     }
 
     @Override


### PR DESCRIPTION
Order of operations are as follows:

1. Performs `Dataset<Row>` transformation/processing *once* at beginning of request to reduce the data to the minimal set required to run *all* linear regression models
2. Persists the `Dataset<Row>` to force evaluation and cache in memory
3. Launches all models to be trained on persisted `Dataset<Row>`
4. Unpersists the `Dataset<Row>` to free up executor memory.

Other changes include refactoring, and removal of dead code.