### PR TITLE
submitting multiple concurrent CountSparkTasks for each collection pr…

### DIFF
--- a/env.sh.example
+++ b/env.sh.example
@@ -6,7 +6,6 @@ export DB_NAME="sustaindb"
 export DB_HOST="lattice-100"
 export DB_PORT=27017
 export SPARK_MASTER="spark://lattice-100:8079"
-export SPARK_THREAD_COUNT=4
 export SPARK_EXECUTOR_CORES=5
 export SPARK_EXECUTOR_MEMORY="8G"
 export SPARK_INITIAL_EXECUTORS=5

--- a/src/main/java/org/sustain/SparkManager.java
+++ b/src/main/java/org/sustain/SparkManager.java
@@ -20,10 +20,10 @@ public class SparkManager {
     protected List<String> jars;
     private String sparkMaster;
 
-    public SparkManager(String sparkMaster, int threadCount) {
+    public SparkManager(String sparkMaster) {
         this.sparkMaster = sparkMaster;
         this.jars = new ArrayList();
-        this.executorService = Executors.newFixedThreadPool(threadCount);
+        this.executorService = Executors.newCachedThreadPool();
     }
 
     public void addJar(String jar) {

--- a/src/main/java/org/sustain/modeling/GBoostRegressionModel.java
+++ b/src/main/java/org/sustain/modeling/GBoostRegressionModel.java
@@ -455,7 +455,7 @@ public class GBoostRegressionModel implements SparkTask<Boolean> {
 		try {
 			// Initialize SparkManager
 			SparkManager sparkManager =
-				new SparkManager("spark://lattice-1.cs.colostate.edu:32531", 1);
+				new SparkManager("spark://lattice-1.cs.colostate.edu:32531");
 
 			// Submit task to SparkManager
         	Future<Boolean> future =

--- a/src/main/java/org/sustain/modeling/RFRegressionModel.java
+++ b/src/main/java/org/sustain/modeling/RFRegressionModel.java
@@ -487,7 +487,7 @@ public class RFRegressionModel implements SparkTask<Boolean> {
 		try {
 			// Initialize SparkManager
 			SparkManager sparkManager =
-				new SparkManager("spark://lattice-1.cs.colostate.edu:8079", 1);
+				new SparkManager("spark://lattice-1.cs.colostate.edu:8079");
 
 			// Submit task to SparkManager
         	Future<Boolean> future =

--- a/src/main/java/org/sustain/server/SustainServer.java
+++ b/src/main/java/org/sustain/server/SustainServer.java
@@ -51,7 +51,7 @@ public class SustainServer {
 
     public void start() throws IOException {
         // initialize SparkManager
-        sparkManager = new SparkManager(Constants.Spark.MASTER, Constants.Spark.THREAD_COUNT);
+        sparkManager = new SparkManager(Constants.Spark.MASTER);
 
         for (String jar: sparkJarPaths) {
             log.info("Adding dependency JAR to the Spark Context: {}", jar);

--- a/src/main/java/org/sustain/util/Constants.java
+++ b/src/main/java/org/sustain/util/Constants.java
@@ -18,7 +18,6 @@ public class Constants {
 
     public static class Spark {
         public static final String MASTER = System.getenv("SPARK_MASTER");
-        public static final Integer THREAD_COUNT = Integer.parseInt(System.getenv("SPARK_THREAD_COUNT"));
         public static final String EXECUTOR_CORES = System.getenv("SPARK_EXECUTOR_CORES");
         public static final String EXECUTOR_MEMORY = System.getenv("SPARK_EXECUTOR_MEMORY");
         public static final String INITIAL_EXECUTORS = System.getenv("SPARK_INITIAL_EXECUTORS");

--- a/src/main/proto/sustain.proto
+++ b/src/main/proto/sustain.proto
@@ -270,11 +270,11 @@ message Query {
 }
 
 message CountRequest {
-  string collection = 1;
+  repeated string collections = 1;
 }
 
 message CountResponse {
-  int64 count = 1;
+  repeated int64 count = 1;
 }
 
 message DirectRequest {


### PR DESCRIPTION
…ovided in CountQuery

Also converted the SparkManager ExecutorService to a CachedThreadPool, which grows and shrinks according to workload. Therefore, we no longer need to set SPARK_THREAD_COUNT in env.sh.