### PR TITLE
Update Modeling Pipeline, Fix Stuff

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -33,9 +33,11 @@ spec:
         image: sustain/sustain-query-service:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 50051
-        - containerPort: 50052
-        - containerPort: 9079
+        - containerPort: 50051 # SQS gRPC Service
+        - containerPort: 50052 # Spark Driver Port
+        - containerPort: 50053 # Spark Driver BlockManager Port
+        - containerPort: 4040  # Spark Driver UI Port
+        - containerPort: 9079  # Default Executor Port
         env:
           - name: NODE_HOSTNAME
             valueFrom:
@@ -49,6 +51,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: KUBERNETES_ENV # Tells SQS it is running in a K8s Pod
+            value: "true"
           - name: SERVER_PORT
             value: "50051"
           - name: DB_NAME
@@ -57,6 +61,14 @@ spec:
             value: "localhost"
           - name: DB_PORT
             value: "27018"
+          - name: SPARK_DRIVER_PORT
+            value: "50052"
+          - name: SPARK_DRIVER_BLOCKMANAGER_PORT
+            value: "50053"
+          - name: SPARK_DRIVER_UI_PORT
+            value: "4040"
+          - name: SPARK_DEFAULT_EXECUTOR_PORT
+            value: "9079"
           - name: SPARK_MASTER
             value: "spark://lattice-100.cs.colostate.edu:8079"
           - name: SPARK_DRIVER_PORT

--- a/src/main/java/org/sustain/SparkManager.java
+++ b/src/main/java/org/sustain/SparkManager.java
@@ -39,14 +39,14 @@ public class SparkManager {
     }
 
     protected SparkSession getOrCreateSparkSession() {
-        // get or create SparkSession
         SparkSession sparkSession = SparkSession.builder()
             .master(this.sparkMaster)
-            .appName("sustain-query-service-" + Constants.Server.HOST)
+            .appName("sqs-" + Constants.Server.HOST)
             .config("spark.submit.deployMode", "client") // Launch driver program locally.
             .config("spark.driver.bindAddress", "0.0.0.0") // Hostname or IP address where to bind listening sockets.
             .config("spark.driver.host", Constants.Kubernetes.POD_IP) // Hostname or IP address for the driver. This is used for communicating with the executors and the standalone Master.
             .config("spark.driver.port", Constants.Spark.DRIVER_PORT) // Port for the driver to listen on. This is used for communicating with the executors and the standalone Master.
+            .config("spark.driver.blockManager.port", Constants.Spark.DRIVER_BLOCKMANAGER_PORT) // Port for driver's blockmanager
             .config("spark.executor.cores", Constants.Spark.EXECUTOR_CORES)
             .config("spark.executor.memory", Constants.Spark.EXECUTOR_MEMORY)
             .config("spark.dynamicAllocation.enabled", "true")
@@ -59,7 +59,7 @@ public class SparkManager {
             .config("mongodb.keep_alive_ms", "100000")
             .getOrCreate();
 
-        // if they don't exist - add JARs to SparkContext
+        // if they don't exist, add JARs to SparkContext
         JavaSparkContext sparkContext =
             new JavaSparkContext(sparkSession.sparkContext());
         for (String jar : this.jars) {

--- a/src/main/java/org/sustain/server/SustainServer.java
+++ b/src/main/java/org/sustain/server/SustainServer.java
@@ -37,10 +37,19 @@ public class SustainServer {
      * Logs the environment variables that the server was started with.
      */
     public static void logEnvironment() {
+        if (Constants.Kubernetes.KUBERNETES_ENV) {
+            log.info("Running within a Kubernetes Pod (KUBERNETES_ENV = true)");
+            log.info("\n\n--- Kubernetes Environment ---\n" +
+                            "NODE_HOSTNAME: {}\n" +
+                            "POD_NAME: {}\n" +
+                            "POD_IP: {}\n",
+                    Constants.Kubernetes.NODE_HOSTNAME, Constants.Kubernetes.POD_NAME, Constants.Kubernetes.POD_IP
+            );
+        } else {
+            log.info("Running directly on host OS");
+        }
+
         log.info("\n\n--- Server Environment ---\n" +
-                "NODE_HOSTNAME: {}\n" +
-                "POD_NAME: {}\n" +
-                "POD_IP: {}\n" +
                 "JAVA_HOME: {}\n" +
                 "SERVER_HOST: {}\n" +
                 "SERVER_PORT: {}\n" +
@@ -48,22 +57,24 @@ public class SustainServer {
                 "DB_HOST: {}\n" +
                 "DB_PORT: {}\n" +
                 "DB_NAME: {}\n" +
-                "DB_USERNAME: {}\n" +
-                "DB_PASSWORD: {}\n" +
                 "\n\n--- Spark Environment ---\n" +
                 "SPARK_MASTER: {}\n" +
                 "SPARK_DRIVER_PORT: {}\n" +
+                "SPARK_DRIVER_BLOCKMANAGER_PORT: {}\n" +
+                "SPARK_DRIVER_UI_PORT: {}\n" +
+                "SPARK_DEFAULT_EXECUTOR_PORT: {}\n" +
                 "EXECUTOR_CORES: {}\n" +
                 "EXECUTOR_MEMORY: {}\n" +
                 "INITIAL_EXECUTORS: {}\n" +
                 "\n\n--- Druid Environment ---\n" +
                 "QUERY_HOST: {}\n" +
                 "QUERY_POST: {}\n",
-                Constants.Kubernetes.NODE_HOSTNAME, Constants.Kubernetes.POD_NAME, Constants.Kubernetes.POD_IP,
                 Constants.Java.HOME,
                 Constants.Server.HOST, Constants.Server.PORT,
-                Constants.DB.HOST, Constants.DB.PORT, Constants.DB.NAME, Constants.DB.USERNAME, Constants.DB.PASSWORD,
-                Constants.Spark.MASTER, Constants.Spark.DRIVER_PORT, Constants.Spark.EXECUTOR_CORES, Constants.Spark.EXECUTOR_MEMORY, Constants.Spark.INITIAL_EXECUTORS,
+                Constants.DB.HOST, Constants.DB.PORT, Constants.DB.NAME,
+                Constants.Spark.MASTER, Constants.Spark.DRIVER_PORT, Constants.Spark.DRIVER_BLOCKMANAGER_PORT,
+                Constants.Spark.DRIVER_UI_PORT, Constants.Spark.DEFAULT_EXECUTOR_PORT,
+                Constants.Spark.EXECUTOR_CORES, Constants.Spark.EXECUTOR_MEMORY, Constants.Spark.INITIAL_EXECUTORS,
                 Constants.Druid.QUERY_HOST, Constants.Druid.QUERY_PORT
         );
     }

--- a/src/main/java/org/sustain/util/Constants.java
+++ b/src/main/java/org/sustain/util/Constants.java
@@ -4,9 +4,10 @@ public class Constants {
     public static final String GIS_JOIN = "GISJOIN";
 
     public static class Kubernetes {
-        public static final String NODE_HOSTNAME = System.getenv("NODE_HOSTNAME");
-        public static final String POD_NAME = System.getenv("POD_NAME");
-        public static final String POD_IP = System.getenv("POD_IP");
+        public static final Boolean KUBERNETES_ENV = System.getenv("KUBERNETES_ENV").equals("true");
+        public static final String  NODE_HOSTNAME = System.getenv("NODE_HOSTNAME");
+        public static final String  POD_NAME = System.getenv("POD_NAME");
+        public static final String  POD_IP = System.getenv("POD_IP");
     }
 
     public static class Server {
@@ -25,6 +26,9 @@ public class Constants {
     public static class Spark {
         public static final String MASTER = System.getenv("SPARK_MASTER");
         public static final String DRIVER_PORT = System.getenv("SPARK_DRIVER_PORT");
+        public static final String DRIVER_BLOCKMANAGER_PORT = System.getenv("SPARK_DRIVER_BLOCKMANAGER_PORT");
+        public static final String DRIVER_UI_PORT = System.getenv("SPARK_DRIVER_UI_PORT");
+        public static final String DEFAULT_EXECUTOR_PORT = System.getenv("SPARK_DEFAULT_EXECUTOR_PORT");
         public static final String EXECUTOR_CORES = System.getenv("SPARK_EXECUTOR_CORES");
         public static final String EXECUTOR_MEMORY = System.getenv("SPARK_EXECUTOR_MEMORY");
         public static final String INITIAL_EXECUTORS = System.getenv("SPARK_INITIAL_EXECUTORS");


### PR DESCRIPTION
Work-in-progress PR : *DO NOT MERGE YET*

Items tackled are as follows:

- Updated environment variables set in `deployment.yaml` to expose container ports for Spark Driver UI, Spark Driver, Spark Executor (not yet used), and Spark Driver's BlockManager.
- Updated `sparkSession` config to deploy a driver locally within the pod, that can be communicated with by Spark Workers running elsewhere in the cluster, on the host OS.
- Updated logging to semi-dynamically show the environment and its config, based on whether we are running in K8s or on the host.


